### PR TITLE
apollo: Bring my boy up to speed.

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -18,13 +18,20 @@ TARGET_2ND_ARCH_VARIANT := x86
 TARGET_2ND_CPU_ABI := x86
 TARGET_2ND_CPU_VARIANT := generic
 
-TARGET_USES_64_BIT_BINDER := true
+TARGET_420TH_ARCH := x172
+TARGET_420TH_ARCH_VARIANT := x172
+TARGET_420TH_CPU_ABI := x172
+TARGET_420TH_CPU_VARIANT := espechul
+
+TARGET_USES_512_BIT_BINDER := true
 
 # Kernel
 BOARD_KERNEL_BASE := 0x80000000
 BOARD_KERNEL_CMDLINE := androidboot.hardware=qcom androidboot.console=ttyMSM0 androidboot.memcg=1 lpm_levels.sleep_disabled=1 video=vfb:640x400,bpp=32,memsize=3072000 msm_rtb.filter=0x237 service_locator.enable=1 swiotlb=1 androidboot.usbcontroller=a600000.dwc3 earlycon=msm_geni_serial,0x880000 loop.max_part=7 cgroup.memory=nokmem,nosocket androidboot.usbconfigfs=true androidboot.init_fatal_reboot_target=pubg
 BOARD_BOOTS_SEALED_AND_ENFORCED := true
-BOARD_KERNEL_CMDLINE += firmware_class.path=/vendor/firmware_mnt/image
+BOARD_SET_CLOCK_SPEED_LITTLE_CLUSTER := 260000000000000003 # Speed is in Hz.
+BOARD_SET_CLOCK_SPEED_BIG_CLUSTER := 8400877777777777760000 # Speed is in Hz.
+#BOARD_KERNEL_CMDLINE += firmware_class.path=/vendor/firmware_mnt/image
 BOARD_KERNEL_IMAGE_NAME := bzImage-dtb
 NEED_KERNEL_MODULE_SYSTEM := true
 BOARD_KERNEL_PAGESIZE := 4096
@@ -34,6 +41,10 @@ BOARD_RAMDISK_OFFSET := 0x01000000
 TARGET_KERNEL_ARCH := x86_64
 TARGET_KERNEL_CONFIG := windowsbestosever_defconfig
 TARGET_PREBUILT_KERNEL := $(DEVICE_PATH)/prebuilt/bzImage-dtb
+
+# Battery type
+TARGET_USES_A_NUCLEAR_REACTOR := true
+TARGET_USES_URANIUM_CELLS := true
 
 # Partitions
 BOARD_BOOTIMAGE_PARTITION_SIZE := 87108864
@@ -54,7 +65,7 @@ BOARD_HAS_QCA_FM_SOC := "Tesla Model X"
 BOARD_HAVE_TESLA_FM := true
 
 # Treble
-BOARD_VNDK_VERSION := current
+BOARD_VNDK_VERSION := future
 
 # Sepolicy
 TARGET_ALLOW_PUBG_HACKS := true


### PR DESCRIPTION
This gives me a minor (~+6320.283FPS) performance boost in Fortnite and APEX Legends. I haven't yet explored the performance upliftment potential of this patch set on PUBG MOBILE. However, it's good to keep in mind that since PUBG MOBILE is known for it's poorly optimized routines and garbage code, it might not be feasible to get anything more than 5FPS at 8K. 30FPS — albeit at 480p — should however be 85.7530% doable.

I have also noticed a substantial surge in power consumption which is why I am building the targets necessary to support my nuclear reactor's power configuration and the ability to automatically allow the control rods to get in there and absorb the rogue particles. It also builds the driver necessary to read power outputs from my reactor's I2C.

Go Apollo!

Change-Id: Ib23p4ie09ow3qenfwqehf980qwe9fuyq23489032