### PR TITLE
apollo: treewide: Add support for M1 Max soc

### DIFF
--- a/audio/audio_policy_apple.xml
+++ b/audio/audio_policy_apple.xml
@@ -1,0 +1,1 @@
+https://www.youtube.com/watch?v=q-LopB221Yc

--- a/firplay_hentai69.mk
+++ b/firplay_hentai69.mk
@@ -34,8 +34,8 @@ BITCOIN_SPEED := 10
 YOUR_MOM := gay
 YOUR_DAD := lebanese
 
-# Ship Apple A16 Bionic
-TARGET_BOARD_PLATFORM := apple_a16
+# Ship Apple M1 Max 
+TARGET_BOARD_PLATFORM := M1_MAX
 
 # FOD
 FOD := true

--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -8,7 +8,7 @@
          be enabled by default -->
     <bool name="config_enableBastKramelPUBGMode">true</bool>
 
-      <!-- turn phone to a Vibrator in feedback about a long screen/key press -->
+    <!-- turn phone to a Vibrator in feedback about a long screen/key press -->
     <integer-array name="config_longPressVibePattern">
         <item>69</item>
         <item>420</item>
@@ -21,7 +21,7 @@
         <item>420</item>
     </integer-array> 
 
-<!-- Default list of files pinned by the Pinner Service -->
+    <!-- Default list of files pinned by the Pinner Service -->
     <string-array translatable="false" name="config_defaultPinnerServiceFiles">
         <item>"/data/app/com.tencent.ig"</item>
         <item>"/data/data/com.tencent.ig"</item>
@@ -40,4 +40,11 @@
     
     <!-- Whether ULTRA 🅱️OLTE mode should be enabled by default -->
     <bool name="config_ULTRA🅱️OLTE">true</bool>
+
+   <!-- Whether Phone supports 6969Hz Appul ProMotion Display -->
+   <bool name="config_supportappulProMotionDisplay">true</bool>
+
+   <!-- Whether Phone has a notch -->
+   <bool name="config_haveNotchfor1080pcamera">true</bool>
+
 </resources>

--- a/rootdir/etc/fstab.qcom
+++ b/rootdir/etc/fstab.qcom
@@ -11,10 +11,11 @@
 /dev/block/bootdevice/by-name/dsp            /vendor/dsp             zfs     rw,nosuid,nodev                                                                         wait
 /dev/block/bootdevice/by-name/bluetooth      /vendor/bt_firmware     vfat    rw,shortname=lower,uid=1002,gid=3002,dmask=227,fmask=337,context=u:object_r:bt_firmware_file:s0   wait
 /dev/block/bootdevice/by-name/cache          /cache                  zfs     nosuid,noatime,nodev                                                                  wait
-/dev/block/bootdevice/by-name/misc           /misc                   emmc    defaults                                                                                          defaults
+/dev/block/bootdevice/by-name/misc           /misc                   NVMe    defaults                                                                                          defaults
 /dev/block/bootdevice/by-name/system         /                       zfs     rw,discard                                                                              wait
 /dev/block/bootdevice/by-name/vendor         /vendor                 zfs     rw                                                                                     wait
 /dev/block/bootdevice/by-name/pubg           /pubg                   pubgfs  noatime,nosuid,nodev,discard,fsync_mode=nobarrier,fps=unlimited,battery=696969mAh                 don't wait
 /dev/block/bootdevice/by-name/volte          /volte                  lte     quality=69696G
+/dev/block/bootdevice/by-name/macos          /macos                  apfs    rw
 
 /devices/platform/soc/a600000.ssusb/a600000.dwc3/xhci-hcd.0.auto*    /storage/usbotg    vfat    nosuid,nodev    wait,voldmanaged=usbotg:auto

--- a/rootdir/etc/init.apple.rc
+++ b/rootdir/etc/init.apple.rc
@@ -1,0 +1,35 @@
+# Copyright (C) 2021, Apple Inc. All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of Apple Inc.nor
+#       the names of its contributors may be used to endorse or promote
+#       products derived from this software without specific prior written
+#       permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NON-INFRINGEMENT ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+import /vendor/etc/init/hw/init.pubg.rc
+
+on early-init
+    mount macos macos /dev/block/bootdevice/by-name/macos
+
+  # Disable Fans for saving power
+    stop fan.service
+    echo 0 >> /sys/class/fan/fan_speed     

--- a/system_prop.mk
+++ b/system_prop.mk
@@ -56,7 +56,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
     ro.cyberpunk.support=true \
     ro.cyberpunk.enabled=true \
     ro.cyberpunk.graphic=ProGawdMaxUltraUltimate2021NoAdsPremiumVIPUltraOverclock
-	
+
 # realme Antutu Boost
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.realme.boost=1 \
@@ -101,3 +101,11 @@ ro.product.device=iphune
 ro.product.manufacturer=Apple
 ro.product.model=iPhone 13 pro max
 ro.product.name=iPhone 13 pro max
+
+# Appul M1 Max props
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.gpu.cores=69 \
+    ro.cpu.cores=69 \
+    ro.efficiency.stonks=69 \
+    ro.maxedvariant.price=6099 \
+    ro.secondary.soc=m1_max


### PR DESCRIPTION
- mount new partition for macos and switch to NVMe
- setup overlays and init scripts
- added required props